### PR TITLE
reorganize key manager section and add certificate manager tooling

### DIFF
--- a/content/articles/manager-tools.md
+++ b/content/articles/manager-tools.md
@@ -225,7 +225,7 @@ Manages cryptographic keys for encryption, decryption, and signing operations.
     Hardware-based devices for secure key generation, storage, and cryptographic operations.
 
     - [AWS CloudHSM](https://aws.amazon.com/cloudhsm/)
-    - [SoftHSM](https://www.opendnssec.org/softhsm/)
+    - [SoftHSM](https://github.com/softhsm/SoftHSMv2)
     - [OpenSC](https://github.com/OpenSC/OpenSC)
 
 5. Artifact Signing & Verification

--- a/content/articles/manager-tools.md
+++ b/content/articles/manager-tools.md
@@ -198,14 +198,50 @@ Manages sensitive information and secrets at rest, in transit, and in use.
 
 Manages cryptographic keys for encryption, decryption, and signing operations.
 
-- [AWS KMS](https://aws.amazon.com/kms/)
-- [HashiCorp Vault](https://developer.hashicorp.com/vault)
-- [Google Cloud Key Management](https://cloud.google.com/kms)
-- [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/)
-- [Age](https://age-encryption.org/)
-- [Keycloak](https://www.keycloak.org/)
-- [Bitwarden](https://bitwarden.com/)
-- [Vaultwarden](https://github.com/dani-garcia/vaultwarden)
+1. Cloud Key Management Service (KMS)
+
+    Managed cloud services for creating, storing, and controlling access to cryptographic keys.
+
+    - [AWS KMS](https://aws.amazon.com/kms/)
+    - [Google Cloud Key Management](https://cloud.google.com/kms)
+    - [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/)
+
+2. Self-Hosted Key Management
+
+    On-premises or self-hosted solutions for key and secrets management.
+
+    - [HashiCorp Vault](https://developer.hashicorp.com/vault)
+    - [Bitwarden](https://bitwarden.com/)
+    - [Vaultwarden](https://github.com/dani-garcia/vaultwarden)
+
+3. Hardware Security Module (HSM)
+
+    Hardware-based devices for secure key generation, storage, and cryptographic operations.
+
+    - [AWS CloudHSM](https://aws.amazon.com/cloudhsm/)
+    - [SoftHSM](https://www.opendnssec.org/softhsm/)
+    - [OpenSC](https://github.com/OpenSC/OpenSC)
+
+4. Artifact Signing & Verification
+
+    Tools for signing and verifying software artifacts, container images, and supply chain components.
+
+    - [Sigstore](https://www.sigstore.dev/)
+    - [Notary](https://github.com/notaryproject/notary)
+    - [Notation](https://notaryproject.dev/)
+
+5. Encryption Tools
+
+    Lightweight tools for file and data encryption using modern cryptographic algorithms.
+
+    - [Age](https://age-encryption.org/)
+    - [GnuPG](https://gnupg.org/)
+
+6. Identity & Access Management
+
+    Identity and authentication platforms that integrate with key-based access controls.
+
+    - [Keycloak](https://www.keycloak.org/)
 
 ### 1.12. Cache Manager
 

--- a/content/articles/manager-tools.md
+++ b/content/articles/manager-tools.md
@@ -233,7 +233,6 @@ Manages cryptographic keys for encryption, decryption, and signing operations.
     Tools for signing and verifying software artifacts, container images, and supply chain components.
 
     - [Sigstore](https://www.sigstore.dev/)
-    - [Notary](https://github.com/notaryproject/notary)
     - [Notation](https://notaryproject.dev/)
 
 6. Encryption Tools

--- a/content/articles/manager-tools.md
+++ b/content/articles/manager-tools.md
@@ -198,7 +198,7 @@ Manages sensitive information and secrets at rest, in transit, and in use.
 
 Manages cryptographic keys for encryption, decryption, and signing operations.
 
-1. Cloud Key Management Service (KMS)
+1. Cloud Key Management Service
 
     Managed cloud services for creating, storing, and controlling access to cryptographic keys.
 

--- a/content/articles/manager-tools.md
+++ b/content/articles/manager-tools.md
@@ -214,7 +214,13 @@ Manages cryptographic keys for encryption, decryption, and signing operations.
     - [Bitwarden](https://bitwarden.com/)
     - [Vaultwarden](https://github.com/dani-garcia/vaultwarden)
 
-3. Hardware Security Module (HSM)
+3. Certificate Manager
+
+    Manages the creation, distribution, and lifecycle of x509 and TLS certificates.
+
+    - [Canonical Notary](https://github.com/canonical/notary)
+
+4. Hardware Security Module (HSM)
 
     Hardware-based devices for secure key generation, storage, and cryptographic operations.
 
@@ -222,7 +228,7 @@ Manages cryptographic keys for encryption, decryption, and signing operations.
     - [SoftHSM](https://www.opendnssec.org/softhsm/)
     - [OpenSC](https://github.com/OpenSC/OpenSC)
 
-4. Artifact Signing & Verification
+5. Artifact Signing & Verification
 
     Tools for signing and verifying software artifacts, container images, and supply chain components.
 
@@ -230,14 +236,14 @@ Manages cryptographic keys for encryption, decryption, and signing operations.
     - [Notary](https://github.com/notaryproject/notary)
     - [Notation](https://notaryproject.dev/)
 
-5. Encryption Tools
+6. Encryption Tools
 
     Lightweight tools for file and data encryption using modern cryptographic algorithms.
 
     - [Age](https://age-encryption.org/)
     - [GnuPG](https://gnupg.org/)
 
-6. Identity & Access Management
+7. Identity & Access Management
 
     Identity and authentication platforms that integrate with key-based access controls.
 

--- a/content/articles/manager-tools.md
+++ b/content/articles/manager-tools.md
@@ -216,7 +216,7 @@ Manages cryptographic keys for encryption, decryption, and signing operations.
 
 3. Certificate Manager
 
-    Manages the creation, distribution, and lifecycle of x509 and TLS certificates.
+    Manages the creation, distribution, and lifecycle of X.509 and TLS certificates.
 
     - [Canonical Notary](https://github.com/canonical/notary)
 


### PR DESCRIPTION
Updates the **Key Manager** section in `content/articles/manager-tools.md` to improve structure and coverage.

### Changes Made

- Reorganized the section into clearer numbered subcategories for key-management related tooling.
- Updated subcategory naming for consistency (including removing redundant abbreviation usage in headings).
- Added a **Certificate Manager** subcategory with:
  - A description covering X.509/TLS certificate lifecycle management.
  - `Canonical Notary` as a tool entry.
- Renumbered subsequent subcategories to keep ordering consistent.

This is a documentation-only change and does not modify runtime functionality.