### PR TITLE
chore: refine Renovate configuration and workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,23 +8,28 @@ on:
     # Run weekly on Sundays at 4:00 AM UTC
     - cron: "0 4 * * 0"
 
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
   renovate:
     name: Renovate Action
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      checks: read
-      id-token: write
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run Renovate
-        uses: sentenz/actions/renovate@1.4.1
+        uses: sentenz/actions/renovate@99935197a6935a691cb151a3e469f1a969bf7714 # 1.4.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          autodiscover: "true"
-          log-level: "info"
+          token: ${{ secrets.RENOVATE_TOKEN }}
+          autodiscover: "false"
+        env:
+          RENOVATE_CONFIG_VALIDATION_ERROR: "true"

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "rebaseWhen": "auto",
+  "rebaseWhen": "behind-base-branch",
   "minimumReleaseAge": "1 day",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "internalChecksFilter": "strict",
@@ -11,6 +11,7 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "ignorePaths": [
+    "**/vendor/**",
     "**/node_modules/**",
     "**/bower_components/**",
     "**/charts/**",
@@ -36,10 +37,11 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update versioned container image references in GitHub Actions files",
+      "description": "Update versioned Docker image references in GitHub Actions metadata.",
       "managerFilePatterns": [
         "**/action.{yml,yaml}"
       ],
+      "matchStringsStrategy": "any",
       "matchStrings": [
         "(?<depName>(?:(?:[A-Za-z0-9.-]+(?::[0-9]+)?/)?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*)):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
@@ -49,23 +51,50 @@
     },
     {
       "customType": "regex",
-      "description": "Update versioned container image references in Makefiles",
+      "description": "Update versioned Docker image references in Makefiles.",
       "managerFilePatterns": [
         "**/[Mm]akefile",
         "**/GNUMakefile",
         "**/*.mk"
       ],
+      "matchStringsStrategy": "any",
       "matchStrings": [
-        "(?<depName>(?:(?:docker\\.io|ghcr\\.io|quay\\.io|gcr\\.io|mcr\\.microsoft\\.com|registry\\.gitlab\\.com|cgr\\.dev|oci\\.io)/)?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
+        "(?<depName>(?:(?:[A-Za-z0-9.-]+(?::[0-9]+)?/)?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+)):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
-      "autoReplaceStringTemplate": "{{depName}}:{{newValue}}{{#if newDigest}}@{{newDigest}}{{else}}{{#if currentDigest}}@{{currentDigest}}{{/if}}{{/if}}",
+      "autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{else}}{{#if currentDigest}}@{{{currentDigest}}}{{/if}}{{/if}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }
   ],
   "packageRules": [
     {
-      "description": "Introduces breaking changes or requires code adjustments due to changes in public APIs.",
+      "description": "Defer repository-based GitHub Actions dependencies to Dependabot.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "action",
+        "uses-with",
+        "github-runner"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Defer Dev Container feature dependencies to Dependabot.",
+      "matchManagers": [
+        "devcontainer"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Group major updates.",
+      "matchManagers": [
+        "!github-actions",
+        "!devcontainer"
+      ],
+      "matchDatasources": [
+        "!docker"
+      ],
       "matchUpdateTypes": [
         "major"
       ],
@@ -74,7 +103,14 @@
       "automerge": false
     },
     {
-      "description": "Introduces backward-compatible functionality improvements and feature additions.",
+      "description": "Group minor updates.",
+      "matchManagers": [
+        "!github-actions",
+        "!devcontainer"
+      ],
+      "matchDatasources": [
+        "!docker"
+      ],
       "matchUpdateTypes": [
         "minor"
       ],
@@ -83,7 +119,14 @@
       "automerge": false
     },
     {
-      "description": "Introduces backward-compatible bug fixes and small corrections.",
+      "description": "Group patch updates.",
+      "matchManagers": [
+        "!github-actions",
+        "!devcontainer"
+      ],
+      "matchDatasources": [
+        "!docker"
+      ],
       "matchUpdateTypes": [
         "patch"
       ],
@@ -92,10 +135,20 @@
       "automerge": false
     },
     {
-      "description": "Container image digest bumps across Dockerfiles and Containerfiles.",
+      "description": "Pin Dockerfile and Containerfile images to immutable digests.",
       "matchManagers": [
-        "dockerfile",
-        "containerfile"
+        "dockerfile"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "Group Dockerfile and Containerfile image updates.",
+      "matchManagers": [
+        "dockerfile"
       ],
       "matchDatasources": [
         "docker"
@@ -106,12 +159,24 @@
         "patch",
         "digest"
       ],
-      "groupName": "container digests",
-      "groupSlug": "container-digests",
+      "pinDigests": true,
+      "groupName": "dockerfile container images",
+      "groupSlug": "dockerfile-container-images",
       "automerge": false
     },
     {
-      "description": "Container image tag and digest updates in Makefiles.",
+      "description": "Pin custom-manager Docker images to immutable digests.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "Group Docker image updates in Makefiles.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -129,12 +194,13 @@
         "patch",
         "digest"
       ],
+      "pinDigests": true,
       "groupName": "makefile container images",
       "groupSlug": "makefile-container-images",
-      "automerge": false
+      "automerge": true
     },
     {
-      "description": "Container image tag and digest updates in GitHub Actions files.",
+      "description": "Group Docker image updates in GitHub Actions metadata.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -150,12 +216,50 @@
         "patch",
         "digest"
       ],
-      "groupName": "github actions container images",
-      "groupSlug": "github-actions-container-images",
-      "automerge": false,
+      "pinDigests": true,
+      "groupName": "github actions metadata container images",
+      "groupSlug": "github-actions-metadata-container-images",
       "semanticCommits": "enabled",
       "semanticCommitType": "ci",
-      "semanticCommitScope": "deps"
+      "semanticCommitScope": "deps",
+      "automerge": false
+    },
+    {
+      "description": "Pin Docker images used by GitHub Actions to immutable digests.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "docker",
+        "container",
+        "service"
+      ],
+      "pinDigests": true,
+      "automerge": true
+    },
+    {
+      "description": "Group Docker image updates used by GitHub Actions.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "docker",
+        "container",
+        "service"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "pinDigests": true,
+      "groupName": "github actions container images",
+      "groupSlug": "github-actions-container-images",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "deps",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Align Convention's Renovate setup with the hardened policy used by `sentenz/template-terraform`, while preserving Convention-specific dependency ownership and container-image coverage.

## Changes

### Renovate configuration

- use `behind-base-branch` rebasing and add `vendor` to ignored dependency paths
- refine custom Docker regex managers with explicit `matchStringsStrategy` and safe triple-brace replacement templates
- keep generic major/minor/patch groups for non-Docker dependencies only
- defer repository-based GitHub Actions (`action`, `uses-with`, `github-runner`) and Dev Container feature updates to the existing Dependabot configuration to avoid duplicate bot PRs
- replace the nonexistent `containerfile` manager match with Renovate's `dockerfile` manager, which covers both Dockerfiles and Containerfiles
- explicitly pin Dockerfile/Containerfile and custom-manager images to immutable digests
- group Dockerfile/Containerfile, Makefile, GitHub Action metadata, and GitHub Actions container-image updates separately
- enable automerge for Makefile and GitHub Actions container-image updates, matching the Terraform policy

### Renovate workflow

- fix the currently failing authentication path by replacing `${{ secrets.GITHUB_TOKEN }}` with `${{ secrets.RENOVATE_TOKEN }}`
- disable autodiscovery so this repository workflow only processes `sentenz/convention`
- pin `actions/checkout` and `sentenz/actions/renovate` to immutable commit SHAs
- update the Renovate action to 1.4.2
- enable strict Renovate configuration validation with `RENOVATE_CONFIG_VALIDATION_ERROR=true`
- reduce workflow permissions to `contents: read`
- disable persisted checkout credentials
- add concurrency protection and a 30-minute job timeout

## Rationale

The scheduled Renovate run on 2026-08-09 failed before Renovate started because `sentenz/actions/renovate` rejects the workflow `GITHUB_TOKEN` for self-hosted Renovate and requires a dedicated PAT or GitHub App installation token.

Convention also already uses Dependabot for GitHub Actions and Dev Container dependencies. Without explicit Renovate exclusions, fixing the workflow would make both bots manage overlapping ecosystems. This change keeps those responsibilities with Dependabot while retaining Renovate for generic dependencies and Docker/container references.

## Validation

- branch is based on current `main` (`1b0cfa4f3ff0779487ab8ee4ed2cbc7ff1694e3f`)
- only `renovate.jsonc` and `.github/workflows/renovate.yml` are changed
- `renovate.jsonc` parses as JSON
- Renovate workflow parses as YAML
- custom Docker regexes were exercised against current Makefile image references, including Renovate, SOPS, and markdownlint images
- checked current Renovate manager documentation/schema: `dockerfile` covers Dockerfile and Containerfile names; `devcontainer` and `github-actions` are valid managers; GitHub Actions exposes the dependency types used by the ownership rules
- direct CLI validation could not complete in the local execution environment because package retrieval timed out; the workflow now fails closed on Renovate configuration validation

## Prerequisite

The repository or organization must provide a `RENOVATE_TOKEN` secret containing a dedicated GitHub PAT or GitHub App installation token. If that secret is not already configured, the Renovate workflow will remain blocked until it is added.